### PR TITLE
Remove unused Kritik font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap');
 
-/* Add Kritik-trial font */
-@font-face {
-  font-family: 'Kritik-trial';
-  src: url('../fonts/Kritik-Semibold-Trial.woff2') format('woff2');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
 
 @tailwind base;
 @tailwind components;
@@ -69,7 +61,7 @@
   }
 
   h1, h2, h3, h4, h5 {
-    @apply font-kritik;
+    @apply font-playfair;
   }
 }
 

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -23,7 +23,6 @@ export default {
         inter: ['Inter', 'sans-serif'],
         poppins: ['Poppins', 'sans-serif'],
         playfair: ['Playfair Display', 'serif'],
-        kritik: ['Kritik-trial', 'sans-serif'],
         times: ['Times New Roman', 'serif'],
         mexican: ['Permanent Marker', 'cursive'],
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,7 +23,6 @@ export default {
         inter: ['Inter', 'sans-serif'],
         poppins: ['Poppins', 'sans-serif'],
         playfair: ['Playfair Display', 'serif'],
-        kritik: ['Kritik-trial', 'sans-serif'],
         times: ['Times New Roman', 'serif'],
         mexican: ['Permanent Marker', 'cursive'],
       },


### PR DESCRIPTION
## Summary
- drop the `@font-face` block for the missing Kritik font
- change headings to use Playfair Display
- remove `kritik` from Tailwind configs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c0966fc4c83318ed334e5443b12d6